### PR TITLE
base64 inline

### DIFF
--- a/src/pdfiumB64.ts
+++ b/src/pdfiumB64.ts
@@ -1,0 +1,2 @@
+declare const __WASM_BINARY_B64__: string;
+export const pdfiumWasmBase64 = __WASM_BINARY_B64__;


### PR DESCRIPTION
This adds a base 64 inline of the wasm. It is used as the fallback if no url or binary is supplied. It builds separately to the other bundles and is dynamically imported, so it wont be loaded in browser unless needed.

Is this what you meant when you said you wanted an inline of the wasm module? Or did you want it inside the bundle itself? I don't think I got it quite right because vite will include the b64 in dist whether you use it or not, which makes sense because it can't know which init option you want to use. It is still chunked though so it won't be loaded unless need. From the article you sent, I think I need to make another whole bundle which can be imported as @hyzyla/pdfium/slim which doesn't import the b64 inline.

It seems to work in the node demos even though I build it as ES. Also build:watch overwrites it for some reason when you save while in library.ts.