### PR TITLE
fix: use slice instead of subarray for data extraction in PDFiumPage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyzyla/pdfium",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyzyla/pdfium",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyzyla/pdfium",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Universal wrapper for PDFium",
   "type": "module",
   "exports": {

--- a/src/page.ts
+++ b/src/page.ts
@@ -129,7 +129,7 @@ export class PDFiumPage {
     this.module._FPDFBitmap_Destroy(bitmap);
     this.module._FPDF_ClosePage(this.pageIdx);
 
-    const data = this.module.HEAPU8.subarray(ptr, ptr + buffSize);
+    const data = this.module.HEAPU8.slice(ptr, ptr + buffSize);
     this.module.wasmExports.free(ptr);
 
     const image = await this.convertBitmapToImage({


### PR DESCRIPTION
## Issue

When initializing the PDFium library once at application startup and executing multiple renders in parallel, the rendered images would sometimes display weird black bands. This issue did not occur when initializing and destroying the library for each render operation.

## Root Cause
The issue was caused by using `subarray()` instead of `slice()` when accessing the rendered bitmap data. `subarray()` creates a view into the existing memory buffer rather than copying the data. When multiple renders were executed in parallel:
1. Each render operation would allocate memory in the WASM heap
2. After rendering, we'd create a view into that memory with `subarray()`
3. The memory would then be freed
4. If another render operation reused that memory before the first render's data was processed, it would overwrite the data in the shared buffer
5. This resulted in black bands or corrupted images

## Example

By running some benchmarks with [mitata](https://github.com/evanwashere/mitata), I obtained the following result:

![test 0 before](https://github.com/user-attachments/assets/ac3d09ac-a043-40a4-a018-782b663515bd)

This change ensures the output is always correct:

![test 0 after](https://github.com/user-attachments/assets/d009c160-7408-4e3a-a0d0-c51a35186406)
