### PR TITLE
feat: add `instantiateWasm` in `PDFiumLibrary.init` options

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,24 +6,24 @@
   "exports": {
     ".": {
       "node": {
+        "types": "./dist/index.d.ts",
         "import": "./dist/index.esm.js",
-        "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "require": "./dist/index.cjs"
       },
       "browser": {
-        "default": "./dist/index.esm.browser.js",
-        "types": "./dist/index.esm.d.ts"
+        "types": "./dist/index.esm.d.ts",
+        "default": "./dist/index.esm.browser.js"
       },
-      "default": "./dist/index.esm.js",
-      "types": "./dist/index.esm.d.ts"
+      "types": "./dist/index.esm.d.ts",
+      "default": "./dist/index.esm.js"
     },
     "./browser/cdn": {
-      "default": "./dist/index.esm.cdn.js",
-      "types": "./dist/index.esm.cdn.d.ts"
+      "types": "./dist/index.esm.cdn.d.ts",
+      "default": "./dist/index.esm.cdn.js"
     },
     "./browser/base64": {
-      "default": "./dist/index.esm.base64.js",
-      "types": "./dist/index.esm.base64.d.ts"
+      "types": "./dist/index.esm.base64.d.ts",
+      "default": "./dist/index.esm.base64.js"
     },
     "./pdfium.wasm": "./dist/pdfium.wasm",
     "./dist/*": "./dist/*"

--- a/src/index.cjs.ts
+++ b/src/index.cjs.ts
@@ -4,17 +4,24 @@
 export * from "./index.js";
 
 import { PDFiumLibrary as _PDFiumLibrary } from "./library.js";
-import vendor from "./vendor/pdfium.js";
+import PDFiumModule from "./vendor/pdfium.js";
 
 export class PDFiumLibrary extends _PDFiumLibrary {
   static async init(options?: {
     wasmBinary?: ArrayBuffer;
     wasmUrl?: string;
+    instantiateWasm?: (
+      imports: WebAssembly.Imports,
+      successCallback: (module: WebAssembly.Module) => void,
+    ) => WebAssembly.Exports;
   }) {
     return await _PDFiumLibrary.initBase({
-      vendor: vendor,
+      vendor: PDFiumModule,
       wasmBinary: options?.wasmBinary,
       wasmUrl: options?.wasmUrl,
+      instantiateWasm: options?.instantiateWasm,
     });
   }
 }
+
+export { PDFiumModule };

--- a/src/index.esm.base64.ts
+++ b/src/index.esm.base64.ts
@@ -7,7 +7,7 @@
 export * from "./index.js";
 
 import { PDFiumLibrary as _PDFiumLibrary } from "./library.js";
-import vendor from "./vendor/pdfium.esm.js";
+import PDFiumModule from "./vendor/pdfium.esm.js";
 
 function base64ToUint8Array(base64: string) {
   const binaryString = atob(base64);
@@ -34,7 +34,9 @@ export class PDFiumLibrary extends _PDFiumLibrary {
     const wasmBinary = base64ToUint8Array(base64.PDFIUM_WASM_BASE64);
     return await _PDFiumLibrary.initBase({
       wasmBinary: wasmBinary.buffer,
-      vendor: vendor,
+      vendor: PDFiumModule,
     });
   }
 }
+
+export { PDFiumModule };

--- a/src/index.esm.cdn.ts
+++ b/src/index.esm.cdn.ts
@@ -5,7 +5,7 @@
 export * from "./index.js";
 
 import { PDFiumLibrary as _PDFiumLibrary } from "./library.js";
-import vendor from "./vendor/pdfium.esm.js";
+import PDFiumModule from "./vendor/pdfium.esm.js";
 
 // This global variable is defined by Rollup at build time
 declare const __PACKAGE_VERSION__: string;
@@ -30,7 +30,7 @@ export class PDFiumLibrary extends _PDFiumLibrary {
     }
     if (PDFiumLibrary._cache) {
       return await _PDFiumLibrary.initBase({
-        vendor: vendor,
+        vendor: PDFiumModule,
         wasmBinary: PDFiumLibrary._cache,
       });
     }
@@ -38,8 +38,10 @@ export class PDFiumLibrary extends _PDFiumLibrary {
     const response = await fetch(CDN_WASM_LINK, fetchOptions);
     const wasmBinary = await response.arrayBuffer();
     return await _PDFiumLibrary.initBase({
-      vendor: vendor,
+      vendor: PDFiumModule,
       wasmBinary: wasmBinary,
     });
   }
 }
+
+export { PDFiumModule };

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -7,17 +7,24 @@
 export * from "./index.js";
 
 import { PDFiumLibrary as _PDFiumLibrary } from "./library.js";
-import vendor from "./vendor/pdfium.esm.js";
+import PDFiumModule from "./vendor/pdfium.esm.js";
 
 export class PDFiumLibrary extends _PDFiumLibrary {
   static async init(options?: {
     wasmBinary?: ArrayBuffer;
     wasmUrl?: string;
+    instantiateWasm?: (
+      imports: WebAssembly.Imports,
+      successCallback: (module: WebAssembly.Module) => void,
+    ) => WebAssembly.Exports;
   }) {
     return await _PDFiumLibrary.initBase({
-      vendor: vendor,
+      vendor: PDFiumModule,
       wasmBinary: options?.wasmBinary,
       wasmUrl: options?.wasmUrl,
+      instantiateWasm: options?.instantiateWasm,
     });
   }
 }
+
+export { PDFiumModule };

--- a/src/library.ts
+++ b/src/library.ts
@@ -33,18 +33,24 @@ type PDFiumLibraryInitOptions = {
   vendor: (options: t.LoadPdfiumOptions) => Promise<t.PDFium>;
   wasmUrl?: string;
   wasmBinary?: ArrayBuffer;
+  instantiateWasm?: (
+    imports: WebAssembly.Imports,
+    successCallback: (module: WebAssembly.Module) => void,
+  ) => WebAssembly.Exports;
 };
 
 export class PDFiumLibrary {
   private readonly module: t.PDFium;
 
   static async initBase(options: PDFiumLibraryInitOptions) {
-    const { wasmUrl, wasmBinary } = options || {};
+    const { wasmUrl, wasmBinary, instantiateWasm } = options || {};
     const loadOptions: t.LoadPdfiumOptions = {};
     if (wasmUrl) {
       loadOptions.locateFile = (path: string) => wasmUrl;
     } else if (wasmBinary) {
       loadOptions.wasmBinary = wasmBinary;
+    } else if (instantiateWasm) {
+      loadOptions.instantiateWasm = instantiateWasm;
     } else {
       // Node.js will use wasm binary from node_modules, but for browser environment,
       // user must provide the wasm binary or URL

--- a/src/vendor/pdfium.d.ts
+++ b/src/vendor/pdfium.d.ts
@@ -59,6 +59,10 @@ export declare type PDFium = {
 export declare type LoadPdfiumOptions = {
   wasmBinary?: ArrayBuffer;
   locateFile?: (path: string) => string;
+  instantiateWasm?: (
+    imports: WebAssembly.Imports,
+    successCallback: (module: WebAssembly.Module) => void,
+  ) => WebAssembly.Exports;
 };
 
 export declare function loadPdfium(options: LoadPdfiumOptions): Promise<PDFium>;


### PR DESCRIPTION
feat: export vendor as `PDFiumModule` for external use
fix: move `types` field above `default` in `package.json` exports

This PR adds the emscripten's `instantiateWasm` option in `PDFiumLibrary.init` so that we can load or provide wasm module in environments like cloudflare workers as it currently does not support loading wasm module through buffer. This option will allow to pass wasm module to pdfium vendor.
Also, I had to export vendor as `PDFiumModule` for external uses.

Example for cloudflare workers if this PR is merged:

```ts
import { PDFiumLibrary } from '@hyzyla/pdfium';
import pdfiumWasmModule from '@hyzyla/pdfium/pdfium.wasm';

// Just to tell emscripten module that environment is web
if (typeof globalThis.window === 'undefined') globalThis.window = globalThis;

export default {
  async fetch() {
    const library = await PDFiumLibrary.init({
      instantiateWasm(info, receive) {
        const instance = new WebAssembly.Instance(pdfiumWasmModule, info);
        receive(instance);
        return instance.exports;
      },
    });

    // can use library here

    library.destroy();

    return new Response(null);
  },
} satisfies ExportedHandler<Env>;
```

Fixes #31