### PR TITLE
Memory safe render

### DIFF
--- a/src/default.options.ts
+++ b/src/default.options.ts
@@ -1,9 +1,10 @@
-import type { PDFiumScaleAndRender } from "./page.types.js";
+import type { PDFiumScaleAndRender } from './page.types.js';
 
 const DEFAULT_PAGE_RENDER_OPTIONS: PDFiumScaleAndRender = {
   scale: 1,
-  render: "bitmap",
-  colorSpace: "BGRA",
+  render: 'bitmap',
+  colorSpace: 'BGRA',
+  renderFormFields: false,
 };
 
 export { DEFAULT_PAGE_RENDER_OPTIONS };

--- a/src/document.ts
+++ b/src/document.ts
@@ -1,5 +1,5 @@
-import { PDFiumPage } from "./page.js";
-import type * as t from "./vendor/pdfium.js";
+import { PDFiumPage } from './page.js';
+import type * as t from './vendor/pdfium.js';
 
 export class PDFiumDocument {
   private readonly module: t.PDFium;
@@ -14,11 +14,7 @@ export class PDFiumDocument {
   private formIdx: number | null = null;
   private formPtr: number | null = null;
 
-  constructor(options: {
-    module: t.PDFium;
-    documentIdx: number;
-    documentPtr: number;
-  }) {
+  constructor(options: { module: t.PDFium; documentIdx: number; documentPtr: number }) {
     this.module = options.module;
     this.documentPtr = options.documentPtr;
     this.documentIdx = options.documentIdx;
@@ -48,7 +44,7 @@ export class PDFiumDocument {
     const formSize = 256; // we need at least 140 bytes, but let's allocate 256 for safety
     this.formPtr = this.module.wasmExports.malloc(formSize);
     if (this.formPtr === 0) {
-      throw new Error("Failed to allocate memory for form fill environment");
+      throw new Error('Failed to allocate memory for form fill environment');
     }
 
     this.module.HEAPU8.fill(0, this.formPtr, this.formPtr + formSize);
@@ -56,10 +52,11 @@ export class PDFiumDocument {
     // Set "version" field to 2. Version 2 supports XFA and other features
     new DataView(this.module.HEAPU8.buffer).setUint32(this.formPtr, 2, true);
     this.formIdx = this.module._FPDFDOC_InitFormFillEnvironment(this.documentIdx, this.formPtr);
+
     if (this.formIdx === 0) {
       this.module.wasmExports.free(this.formPtr);
       this.formPtr = null;
-      throw new Error("Failed to initialize form fill environment");
+      throw new Error('Failed to initialize form fill environment');
     }
 
     return this.formIdx;

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,11 +1,15 @@
-import { FPDFBitmap, FPDFRenderFlag } from "./constants.js";
-import { DEFAULT_PAGE_RENDER_OPTIONS } from "./default.options.js";
-import type { PDFiumDocument } from "./document.js";
-import { type PDFiumObject, PDFiumObjectBase } from "./objects.js";
-import type { PDFiumPageRender, PDFiumPageRenderOptionsValidated, PDFiumPageRenderParams } from "./page.types.js";
-import type { PDFiumRenderFunction, PDFiumRenderOptions } from "./types.js";
-import { convertBitmapToImage } from "./utils.js";
-import type * as t from "./vendor/pdfium.js";
+import { FPDFBitmap, FPDFRenderFlag } from './constants.js';
+import { DEFAULT_PAGE_RENDER_OPTIONS } from './default.options.js';
+import type { PDFiumDocument } from './document.js';
+import { type PDFiumObject, PDFiumObjectBase } from './objects.js';
+import type {
+  PDFiumPageRender,
+  PDFiumPageRenderOptionsValidated,
+  PDFiumPageRenderParams,
+} from './page.types.js';
+import type { PDFiumRenderFunction, PDFiumRenderOptions } from './types.js';
+import { convertBitmapToImage } from './utils.js';
+import type * as t from './vendor/pdfium.js';
 
 export class PDFiumPage {
   private readonly module: t.PDFium;
@@ -64,14 +68,14 @@ export class PDFiumPage {
   getText(): string {
     const textPage = this.module._FPDFText_LoadPage(this.pageIdx);
     if (!textPage) {
-      throw new Error("Failed to load text page");
+      throw new Error('Failed to load text page');
     }
 
     try {
       const charCount = this.module._FPDFText_CountChars(textPage);
 
       if (charCount <= 0) {
-        return "";
+        return '';
       }
 
       const bufferSize = (charCount + 1) * 2;
@@ -81,13 +85,13 @@ export class PDFiumPage {
         const length = this.module._FPDFText_GetText(textPage, 0, charCount, textPtr);
 
         if (length <= 0) {
-          return "";
+          return '';
         }
 
         // Convert the UTF-16LE buffer to a JavaScript string
         // Subtract 1 from length to remove the null terminator
         const buffer = new Uint8Array(this.module.HEAPU8.buffer, textPtr, (length - 1) * 2);
-        const text = new TextDecoder("utf-16le").decode(buffer);
+        const text = new TextDecoder('utf-16le').decode(buffer);
 
         return text;
       } finally {
@@ -105,51 +109,48 @@ export class PDFiumPage {
       ...options,
     };
 
-    const { colorSpace, render } = renderOptions;
+    const { colorSpace, render, renderFormFields } = renderOptions;
     const { width, height, originalWidth, originalHeight } = this.getSize(renderOptions);
 
-    if (options.renderFormFields) {
+    if (renderFormFields) {
       formIdx = this.document.initializeFormFields(); // will be initialized only once
       this.module._FORM_OnAfterLoadPage(this.pageIdx, formIdx);
     }
 
     const bytesPerPixel = FPDFBitmap[colorSpace];
-
     const buffSize = width * height * bytesPerPixel;
     const ptr = this.module.wasmExports.malloc(buffSize);
 
-    const bitmap = this.module._FPDFBitmap_CreateEx(width, height, bytesPerPixel, ptr, width * bytesPerPixel);
+    if (ptr === 0) {
+      throw new Error('Failed to allocate memory for bitmap');
+    }
 
-    this.module._FPDFBitmap_FillRect(
-      bitmap,
-      0, // left
-      0, // top
-      width, // width
-      height, // height
-      0xffffffff, // color (white)
-    );
+    try {
+      const bitmap = this.module._FPDFBitmap_CreateEx(
+        width,
+        height,
+        bytesPerPixel,
+        ptr,
+        width * bytesPerPixel,
+      );
 
-    let flags = FPDFRenderFlag.ANNOT | FPDFRenderFlag.LCD_TEXT;
+      this.module._FPDFBitmap_FillRect(
+        bitmap,
+        0, // left
+        0, // top
+        width, // width
+        height, // height
+        0xffffffff, // color (white)
+      );
 
-    flags = colorSpace === "Gray" ? flags | FPDFRenderFlag.GRAYSCALE : flags | FPDFRenderFlag.REVERSE_BYTE_ORDER;
+      let flags = FPDFRenderFlag.ANNOT | FPDFRenderFlag.LCD_TEXT;
 
-    this.module._FPDF_RenderPageBitmap(
-      bitmap,
-      this.pageIdx,
-      0, // start_x
-      0, // start_y
-      width, // size_x
-      height, // size_y
-      0, // rotate (0, normal)
-      flags, // flags
-    );
+      flags =
+        colorSpace === 'Gray'
+          ? flags | FPDFRenderFlag.GRAYSCALE
+          : flags | FPDFRenderFlag.REVERSE_BYTE_ORDER;
 
-    if (formIdx) {
-      // Second draw pass – draw the interactive form widgets on top of previously draw call
-      // Remove ANNOT flags to avoid rendering popup annotations (e.g. tooltips).
-      const formFlags = flags & ~FPDFRenderFlag.ANNOT;
-      this.module._FPDF_FFLDraw(
-        formIdx,
+      this.module._FPDF_RenderPageBitmap(
         bitmap,
         this.pageIdx,
         0, // start_x
@@ -157,33 +158,52 @@ export class PDFiumPage {
         width, // size_x
         height, // size_y
         0, // rotate (0, normal)
-        formFlags, // flags
+        flags, // flags
       );
-      this.module._FORM_OnBeforeClosePage(this.pageIdx, formIdx);
+
+      if (formIdx !== null) {
+        // Second draw pass – draw the interactive form widgets on top of previously draw call
+        // Remove ANNOT flags to avoid rendering popup annotations (e.g. tooltips).
+        const formFlags = flags & ~FPDFRenderFlag.ANNOT;
+        this.module._FPDF_FFLDraw(
+          formIdx,
+          bitmap,
+          this.pageIdx,
+          0, // start_x
+          0, // start_y
+          width, // size_x
+          height, // size_y
+          0, // rotate (0, normal)
+          formFlags, // flags
+        );
+
+        this.module._FORM_OnBeforeClosePage(this.pageIdx, formIdx);
+      }
+
+      this.module._FPDFBitmap_Destroy(bitmap);
+
+      // TODO: consider to create a separate function for closing the page and free
+      // resources only when needed, not after every render
+      this.module._FPDF_ClosePage(this.pageIdx);
+
+      const image = await this.convertBitmapToImage({
+        render,
+        width,
+        height,
+        // ⚠️ creation of a copy is necessary to avoid memory corruption
+        data: this.module.HEAPU8.slice(ptr, ptr + buffSize),
+      });
+
+      return {
+        width,
+        height,
+        originalHeight,
+        originalWidth,
+        data: image,
+      };
+    } finally {
+      this.module.wasmExports.free(ptr);
     }
-
-    this.module._FPDFBitmap_Destroy(bitmap);
-
-    // TODO: consider to create a separate function for closing the page and free
-    // resources only when needed, not after every render
-    this.module._FPDF_ClosePage(this.pageIdx);
-
-    const image = await this.convertBitmapToImage({
-      render,
-      width,
-      height,
-      data: Buffer.from(this.module.HEAPU8.buffer, ptr, buffSize),
-    });
-
-    this.module.wasmExports.free(ptr);
-
-    return {
-      width,
-      height,
-      originalHeight,
-      originalWidth,
-      data: image,
-    };
   }
 
   async convertBitmapToImage(

--- a/src/page.types.ts
+++ b/src/page.types.ts
@@ -1,4 +1,4 @@
-import type { PDFiumRenderFunction, PDFiumRenderOptions } from "./types.js";
+import type { PDFiumRenderFunction, PDFiumRenderOptions } from './types.js';
 
 export type PDFiumPageRenderFunction = PDFiumRenderFunction;
 export type PDFiumPageRenderOptions = PDFiumRenderOptions;
@@ -14,21 +14,22 @@ export type PDFiumPageRenderParams = {
   height?: number;
 };
 
-export type ColorSpace = "BGRA" | "Gray";
+export type ColorSpace = 'BGRA' | 'Gray';
 
 export type PDFiumScaleAndRender = {
   scale: number;
   render: PDFiumPageRenderFunction;
   colorSpace: ColorSpace;
+  renderFormFields: boolean;
 };
 
 export type PDFiumPageRenderOptionsValidated = {
   scale: number;
   render: PDFiumPageRenderFunction;
   colorSpace: ColorSpace;
+  renderFormFields: boolean;
   width?: number;
   height?: number;
-  renderFormFields?: boolean;
 };
 
 export type PDFiumPageSize = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,5 @@
-import type { PDFiumRenderFunction, PDFiumRenderOptions } from "./types.js";
+import type { PDFiumRenderFunction, PDFiumRenderOptions } from './types.js';
 
-/**
- * Memory consumption : ONLY copy (slice) in case of bitmap rendering.
- */
 export async function convertBitmapToImage(
   options: {
     render: PDFiumRenderFunction;
@@ -10,11 +7,11 @@ export async function convertBitmapToImage(
 ): Promise<Uint8Array> {
   const { data, render } = options;
 
-  if (typeof render === "function") {
+  if (typeof render === 'function') {
     return await render(options);
   }
 
-  return data.slice();
+  return data;
 }
 
 export function readUInt16LE(buffer: Uint8Array, offset = 0): number {


### PR DESCRIPTION
Hi. 

Further improvements of the render method : 
1. Memory allocation (like in C) can fail, so make sure to check the pointer (and `width` and `height` can be user controlled thus check is necessary)
2. Surround the whole render code into a `try / finally` to **always be sure** that resources are cleaned to avoid memory leaks in case of error
3. Rollback to your version of copying the Uint8Array `this.module.HEAPU8.slice(ptr, ptr + buffSize)` because a Buffer.slice was **not** copying the data but sharing the same view

--- 
About 3. your version was correct, and not mine (sorry !)

POC 

Correct (your version) ✅ : 
```javascript
const bytes = new Uint8Array([10, 20, 30, 40, 50]); // this.module.HEAPU8 is a Uint8Array
const byteSlice = bytes.slice(1, 3);

bytes[1] = 99;
console.log(byteSlice);
// Expected output: Uint8Array [20, 30]
```
-> see here in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice) for the correct version 

Incorrect ❌ : 
```javascript
const buf = Buffer.from([1, 2, 3]);
const slice = buf.slice(0, 2);
slice[0] = 99;
console.log(buf[0]); // 99
```
-> see here in the [Nodejs docs](https://nodejs.org/api/buffer.html#buffers-and-typedarrays) for the incorrect version

Sorry again for point 3 !